### PR TITLE
ubuntu-18.04.ipxe add uefi compatibility

### DIFF
--- a/ubuntu-18.04.ipxe
+++ b/ubuntu-18.04.ipxe
@@ -1,7 +1,14 @@
 #!ipxe
 
-cpuid --ext 29 && set arch amd64
+cpuid --ext 29
 
-initrd http://mirror.leaseweb.com/ubuntu/dists/bionic-updates/main/installer-${arch}/current/images/netboot/ubuntu-installer/${arch}/initrd.gz
-kernel http://mirror.leaseweb.com/ubuntu/dists/bionic-updates/main/installer-${arch}/current/images/netboot/ubuntu-installer/${arch}/linux -- ip=dhcp ksdevice=${mac} hostname=localhost
+set arch amd64
+set dist bionic
+
+set base http://mirror.leaseweb.com/ubuntu/dists/${dist}-updates/main/installer-${arch}/current/images/netboot/ubuntu-installer/${arch}
+set base_nonfree http://cdimage.debian.org/cdimage/unofficial/non-free/firmware/stable/current
+
+kernel ${base}/linux linitrd=initrd.gz linitrd=firmware.cpio.gz locale=en_US.UTF-8 interface=auto ip=dhcp --
+initrd ${base}/initrd.gz
+initrd ${base_nonfree}/firmware.cpio.gz
 boot


### PR DESCRIPTION
This PR adjusts ubuntu-18.04.ipxe to successfully netboot a server in both BIOS and UEFI mode.