### PR TITLE
Add Ubuntu 19.10 Eoan Ermine iPXE with UEFI support

### DIFF
--- a/ubuntu-19.10.ipxe
+++ b/ubuntu-19.10.ipxe
@@ -1,0 +1,14 @@
+#!ipxe
+
+cpuid --ext 29
+
+set arch amd64
+set dist eoan
+
+set base http://mirror.leaseweb.com/ubuntu/dists/${dist}/main/installer-${arch}/current/images/netboot/ubuntu-installer/${arch}
+set base_nonfree http://cdimage.debian.org/cdimage/unofficial/non-free/firmware/stable/current
+
+kernel ${base}/linux linitrd=initrd.gz linitrd=firmware.cpio.gz locale=en_US.UTF-8 interface=auto ip=dhcp --
+initrd ${base}/initrd.gz
+initrd ${base_nonfree}/firmware.cpio.gz
+boot


### PR DESCRIPTION
19.10 is an intermediate version for users waiting for 20.04 to go LTS. 19.04 is EOL since Jan 2020. 