### PR TITLE
IM-16321: Remove deprecated centos-6.ipxe

### DIFF
--- a/centos-6.ipxe
+++ b/centos-6.ipxe
@@ -1,9 +1,0 @@
-#!ipxe
-
-cpuid --ext 29 && set arch x86_64 || set arch i386
-
-set base http://mirror.leaseweb.com/centos/6/os/${arch}
-  
-kernel ${base}/images/pxeboot/vmlinuz initrd=initrd.img repo=${base}
-initrd ${base}/images/pxeboot/initrd.img
-boot


### PR DESCRIPTION
* IM-16321: Remove deprecated centos-6.ipxe